### PR TITLE
fix: use react-router link component for navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "lint:style": "stylelint './**/*.scss'",
     "lint:format": "prettier . --write --ignore-unknown --no-error-on-unmatched-pattern --log-level warn",
     "lint:spell": "cspell lint --quiet \"**\"",
-    "preview:prod": "cross-env NODE_ENV=production node server",
-    "preview": "cross-env NODE_ENV=local node server",
+    "preview:prod": "cross-env NODE_ENV=production node src/server.js",
+    "preview": "cross-env NODE_ENV=local node src/server.js",
     "test": "vitest run --coverage",
     "test:watch": "vitest --watch",
     "prepare": "husky"

--- a/src/components/nav/Nav.jsx
+++ b/src/components/nav/Nav.jsx
@@ -62,7 +62,7 @@ export const Nav = () => {
             to="/dashboard"
             isActive={location.pathname === '/dashboard'}
           >
-            Dashboard Dashboard
+            Dashboard
           </HeaderMenuItem>
           <HeaderMenuItem href="#">Link 2</HeaderMenuItem>
           <HeaderMenuItem href="#">Link 3</HeaderMenuItem>

--- a/src/components/nav/Nav.jsx
+++ b/src/components/nav/Nav.jsx
@@ -30,8 +30,10 @@ import {
   Search,
   Switcher as SwitcherIcon,
 } from '@carbon/icons-react';
+import { useLocation, Link } from 'react-router';
 
 export const Nav = () => {
+  const location = useLocation();
   const [isSideNavExpanded, setIsSideNavExpanded] = useState(false);
 
   const toggleNav = () => {
@@ -51,11 +53,17 @@ export const Nav = () => {
           isActive={isSideNavExpanded}
           aria-expanded={isSideNavExpanded}
         />
-        <HeaderName href="/" prefix="Carbon">
+        <HeaderName as={Link} to="/" prefix="Carbon">
           React starter template
         </HeaderName>
         <HeaderNavigation aria-label="fed-at-ibm">
-          <HeaderMenuItem href="/dashboard">Dashboard</HeaderMenuItem>
+          <HeaderMenuItem
+            as={Link}
+            to="/dashboard"
+            isActive={location.pathname === '/dashboard'}
+          >
+            Dashboard Dashboard
+          </HeaderMenuItem>
           <HeaderMenuItem href="#">Link 2</HeaderMenuItem>
           <HeaderMenuItem href="#">Link 3</HeaderMenuItem>
           <HeaderMenu aria-label="Link 4" menuLinkName="Link 4">


### PR DESCRIPTION
We should not use href with react router when routing within the application. Instead use either the react-router component Link or useNavigation. 

The current route is provided by useLocation.

e.g.

```
<HeaderName as={Link} to='/' >Starter</HeaderName>
```