### PR TITLE
feat: fix theme flash and jitter

### DIFF
--- a/src/entry-client.jsx
+++ b/src/entry-client.jsx
@@ -11,8 +11,6 @@ import { hydrateRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router';
 import { Router } from './routes';
 
-// App level imports
-
 hydrateRoot(
   document.getElementById('root'),
   <StrictMode>

--- a/src/hooks/useThemes.js
+++ b/src/hooks/useThemes.js
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react';
 export const useThemes = () => {
   const prefersDark = usePrefersDarkScheme();
   const [themeReady, setThemeReady] = useState(false);
+  const [updateThemeReady, setUpdateThemeReady] = useState(false);
 
   // Will not resolve to actual theme preferences until after first render
   // monitor themeReady to make use of primary and secondary theme.
@@ -25,8 +26,16 @@ export const useThemes = () => {
       setPrimaryTheme('g10');
       setSecondaryTheme('white');
     }
-    setThemeReady(true);
+
+    setUpdateThemeReady(true);
   }, [prefersDark]);
+
+  useEffect(() => {
+    if (updateThemeReady) {
+      // Theme is only marked as ready after the theme settings have been initialized
+      setThemeReady(true);
+    }
+  }, [updateThemeReady]);
 
   return { primaryTheme, secondaryTheme, themeReady };
 };

--- a/src/index.scss
+++ b/src/index.scss
@@ -24,23 +24,35 @@
 @use 'components/commonHeader/commonHeader';
 @use 'components/footer/footer';
 
-/* system preference theme by default */
-:root {
-  @include theme(themes.$g10);
-
+@mixin light-brand {
   --cs-brand: #{$blue-30};
   --cs-brand-alt: #{$blue-20};
   --cs-logo-filter: invert(100%);
 }
 
+@mixin dark-brand {
+  --cs-brand: #{$blue-80};
+  --cs-brand-alt: #{$blue-90};
+  --cs-logo-filter: initial;
+}
+
+/* system preference theme by default */
+:root,
+:root[cs--theme='g10'] {
+  @include theme(themes.$g10);
+  @include light-brand;
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     @include theme(themes.$g100);
-
-    --cs-brand: #{$blue-80};
-    --cs-brand-alt: #{$blue-90};
-    --cs-logo-filter: initial;
+    @include dark-brand;
   }
+}
+
+:root[cs--theme='g100'] {
+  @include theme(themes.$g100);
+  @include dark-brand;
 }
 
 body {

--- a/src/layouts/page-layout.jsx
+++ b/src/layouts/page-layout.jsx
@@ -5,18 +5,25 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Content } from '@carbon/react';
+import { Content, Theme } from '@carbon/react';
 import { Suspense } from 'react';
 import { Nav } from '../components/nav/Nav';
 import classNames from 'classnames';
+import { useThemes } from '../hooks/useThemes';
 
 export const PageLayout = ({ children, className, fallback }) => {
+  const { primaryTheme, themeReady } = useThemes();
+
   return (
-    <Suspense fallback={fallback}>
-      <div className={classNames('cs--page-layout', className)}>
-        <Nav />
-        <Content className="cs--page-layout-content">{children}</Content>
-      </div>
-    </Suspense>
+    themeReady && (
+      <Suspense fallback={fallback}>
+        <div className={classNames('cs--page-layout', className)}>
+          <Nav />
+          <Theme theme={primaryTheme} as={Content}>
+            <Content className="cs--page-layout-content">{children}</Content>
+          </Theme>
+        </div>
+      </Suspense>
+    )
   );
 };

--- a/src/layouts/theme-layout.jsx
+++ b/src/layouts/theme-layout.jsx
@@ -13,13 +13,13 @@ import { Outlet } from 'react-router';
 export const ThemeLayout = () => {
   const { primaryTheme, themeReady } = useThemes();
 
-  return themeReady ? (
-    <GlobalTheme theme={primaryTheme}>
-      <Theme theme={primaryTheme}>
-        <Outlet />
-      </Theme>
-    </GlobalTheme>
-  ) : (
-    <Outlet />
+  return (
+    themeReady && (
+      <GlobalTheme theme={primaryTheme}>
+        <Theme theme={primaryTheme}>
+          <Outlet />
+        </Theme>
+      </GlobalTheme>
+    )
   );
 };


### PR DESCRIPTION
Rendering content before the theme has been established causes a small amount of theme flash, specifically on buttons in menus and copy buttons.

This fixes that, which also seems to resolve some page jitter on load.