### PR TITLE
fix(welcome): apply wide grid rules

### DIFF
--- a/src/pages/welcome/welcome.scss
+++ b/src/pages/welcome/welcome.scss
@@ -22,10 +22,6 @@
 
 .cs--welcome__dynamic-message {
   margin-block-start: $spacing-05;
-
-  p {
-    margin-inline-start: $spacing-05;
-  }
 }
 
 .cs--welcome__tile {


### PR DESCRIPTION
The welcome page is using Carbon's wide grid. Contrary to the narrow and condensed modes, text outside and inside of containers is not aligned but the outside text is aligned with the container boundaries.

Reference: https://carbondesignsystem.com/elements/2x-grid/usage/#gutter-modes

<img width="1191" height="518" alt="image" src="https://github.com/user-attachments/assets/f6e77273-69e6-4671-8b8d-baaa4488a983" />

This PR removes a style rule that currently indents the text block in the  "An example of data fetching" section.
