### PR TITLE
fix: remove stable gutter

### DIFF
--- a/src/layouts/page-layout.scss
+++ b/src/layouts/page-layout.scss
@@ -88,7 +88,6 @@
   you should manage scrolling withing the component/canvas. 
   */
   overflow: hidden auto; /* no horizontal scroll, vertical only unless manged elsewhere */
-  scrollbar-gutter: stable; /* ensure we do not jump on scroll bar appearance */
   scrollbar-color: $background-active $layer;
 }
 


### PR DESCRIPTION
Unfortunately this causes the page header background not to reach the edge of the screen.

There are various ways of fixing the size, but that has the effect of shifting the PageHeader text, as a result making it slightly offset to the rest of the page. 

In order to keep this we would need to extend the page header background by more the width of the scrollbar. The size of the scrollbar is not available in pure CSS and the background of any potential header, other than IBM Products PageHeader, is not knowable.