### PR TITLE
fix(eslint): update react-hooks  plugin config for v7 and resolve new rule violations

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,7 +52,7 @@ export default [
   importPlugin.flatConfigs.recommended,
   /* added (eslint-plugin-react) - popular recommended config March 24th 2025 */
   pluginReact.configs.flat['jsx-runtime'],
-  ...pluginReactHooks.configs['flat/recommended'],
+  pluginReactHooks.configs.flat.recommended,
   pluginReactRefresh.configs.vite,
   /* added (eslint-plugin-jsx-a11y) - ensures attributes needed for accessibility are added */
   eslintPluginJsxA11y.flatConfigs.recommended,

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -33,7 +33,6 @@ const ThemeContext = createContext({
 export const ThemeProvider = ({ children }) => {
   const prefersDark = usePrefersDarkScheme();
   const [ready, setReady] = useState(false);
-  const [updateReady, setUpdateReady] = useState(false);
 
   // Initialize state from local storage
   const storedValues = getLocalStorageValues();
@@ -79,20 +78,12 @@ export const ThemeProvider = ({ children }) => {
     [themeMenuCompliment],
   );
 
-  const [theme, setTheme] = useState(() => calculateTheme());
-  const [themeMenu, setThemeMenu] = useState(() => {
-    const initialTheme = calculateTheme();
-    return calculateMenuTheme(initialTheme);
-  });
+  // Calculate current theme based on settings
+  const theme = calculateTheme();
+  const themeMenu = calculateMenuTheme(theme);
 
-  // Update themes when settings change
+  // Update the DOM when theme changes
   useEffect(() => {
-    const newTheme = calculateTheme();
-    setTheme(newTheme);
-    setThemeMenu(calculateMenuTheme(newTheme));
-    setUpdateReady(true);
-
-    // Update the document element with the appropriate theme data attribute
     const root = document.documentElement;
 
     // Remove any existing theme data attribute
@@ -100,22 +91,12 @@ export const ThemeProvider = ({ children }) => {
 
     // If not using system theme, add the appropriate data attribute
     if (themeSetting !== 'system') {
-      root.setAttribute('cs--theme', newTheme);
+      root.setAttribute('cs--theme', theme);
     }
-  }, [
-    themeSetting,
-    themeMenuCompliment,
-    prefersDark,
-    calculateTheme,
-    calculateMenuTheme,
-  ]);
 
-  useEffect(() => {
-    if (updateReady) {
-      setReady(true);
-      setUpdateReady(false);
-    }
-  }, [updateReady]);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Setting ready state after DOM synchronization is intentional
+    setReady(true);
+  }, [theme, themeSetting]);
 
   const value = {
     themeSetting,

--- a/src/pages/dashboard/Dashboard.jsx
+++ b/src/pages/dashboard/Dashboard.jsx
@@ -6,6 +6,7 @@
  */
 
 import { Column, Grid, Tile } from '@carbon/react';
+import { useState } from 'react';
 
 import { Footer } from '../../components/footer/Footer';
 import { PageLayout } from '../../layouts/page-layout';
@@ -14,12 +15,14 @@ import { PageLayout } from '../../layouts/page-layout';
 // Do the same unless you have a good reason not to.
 
 const NumberTile = () => {
+  const [activeUsers] = useState(() => Math.round(Math.random() * 1000));
+
   return (
     <Column sm={4} md={4} lg={4} xlg={4}>
       <Tile className="cs--dashboard__tile cs--dashboard__tile--number">
         <dl>
           <dt>Active users</dt>
-          <dd>{Math.round(Math.random() * 1000)}</dd>
+          <dd>{activeUsers}</dd>
         </dl>
       </Tile>
     </Column>


### PR DESCRIPTION
This PR fixes ESLint issues caused by the upgrade of eslint-plugin-react-hooks from v6 → v7 (Nov 7, 2025).
Renovate upgraded the dependency but did not update the corresponding ESLint config, causing pluginReactHooks to load the wrong configuration path.
v7 also introduced stricter rules, which surfaced new violations in our codebase.

The error in `main` branch before this change, if you run `npm run lint`:
```
> carbon-react-starter@0.1.0 lint:es
> eslint . --report-unused-disable-directives --max-warnings 0 --cache --cache-location "node_modules/.cache/eslint/"


Oops! Something went wrong! :(

ESLint: 9.39.1

TypeError: pluginReactHooks.configs.flat/recommended is not iterable
...
...
```

### Changes:
- Updated eslint config to use the correct recommended config path for v7: `pluginReactHooks.configs.flat.recommended`
- Code fixes due to stricter v7 rules