### PR TITLE
fix: correct motion mixin quotes and productive-heading-02 capitalization in SCSS snippets

### DIFF
--- a/.vscode/scss.code-snippets
+++ b/.vscode/scss.code-snippets
@@ -217,7 +217,7 @@
   "@include motion('entrance', 'expressive')": {
     "scope": "scss",
     "prefix": ["mo", "motion"],
-    "body": "@include motion(entrance, 'expressive')",
+    "body": "@include motion('entrance', 'expressive')",
     "description": "Carbon duration token",
   },
   "@include motion('exit', 'productive')": {
@@ -322,10 +322,10 @@
     "body": "@include type-style('heading-02')",
     "description": "Carbon typography token",
   },
-  "@include type-style('productive-Heading-02')": {
+  "@include type-style('productive-heading-02')": {
     "scope": "scss",
     "prefix": ["ty", "type"],
-    "body": "@include type-style('productive-Heading-02')",
+    "body": "@include type-style('productive-heading-02')",
     "description": "Carbon typography token",
   },
   "@include type-style('productive-heading-03')": {


### PR DESCRIPTION
# SCSS Code Snippets Review

## Critical Errors

### 1. **Line 220: Missing quotes in motion mixin**
```scss
"body": "@include motion(entrance, 'expressive')"
```
**Issue:** `entrance` should be quoted as `'entrance'`
**Should be:** `"body": "@include motion('entrance', 'expressive')"`

### 2. **Line 328: Incorrect capitalization**
```scss
"body": "@include type-style('productive-Heading-02')"
```
**Issue:** `Heading` has capital `H`, should be lowercase
**Should be:** `"body": "@include type-style('productive-heading-02')"`

## Summary

**Total Issues Found: 2**

1. **Line 220** - Missing quotes around `entrance` parameter in motion mixin
2. **Line 328** - Incorrect capitalization: `productive-Heading-02` should be `productive-heading-02`

Both issues would cause runtime errors when the snippets are used, as Carbon Design System expects exact token names with consistent lowercase formatting.