### PR TITLE
fix: most font flicker

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -7,7 +7,8 @@
 
 @use '@carbon/ibm-products/css/index.min';
 @use '@carbon/react' with (
-  $font-path: '@ibm/plex'
+  $font-path: '@ibm/plex',
+  $font-display: 'block'
 );
 @use '@carbon/react/scss/spacing' as *;
 @use '@carbon/react/scss/theme' as *;


### PR DESCRIPTION
This prevents font flicker by using font-display: block, or at least passing $font-display to Carbon.

https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@font-face/font-display