### PR TITLE
fix: remove packages imported by carbon react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,7 @@
       "dependencies": {
         "@carbon-labs/react-theme-settings": "^0.18.0",
         "@carbon/ibm-products": "^2.74.0",
-        "@carbon/icons-react": "^11.53.0",
         "@carbon/react": "^1.73.0",
-        "@carbon/styles": "^1.72.0",
         "@ibm/plex": "^6.4.1",
         "@lhci/cli": "^0.15.0",
         "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
   "dependencies": {
     "@carbon-labs/react-theme-settings": "^0.18.0",
     "@carbon/ibm-products": "^2.74.0",
-    "@carbon/icons-react": "^11.53.0",
     "@carbon/react": "^1.73.0",
-    "@carbon/styles": "^1.72.0",
     "@ibm/plex": "^6.4.1",
     "@lhci/cli": "^0.15.0",
     "classnames": "^2.5.1",


### PR DESCRIPTION
Fixes #322 

Removes Carbon package dependencies installed by @carbon/react. Specifically @carbon/styles and @carbon/icons-react