### PR TITLE
fix: header layout

### DIFF
--- a/src/components/commonHeader/CommonHeader.jsx
+++ b/src/components/commonHeader/CommonHeader.jsx
@@ -10,22 +10,22 @@ import { AspectRatio, Column, Grid, Heading } from '@carbon/react';
 export const CommonHeader = ({ title, paragraphs }) => {
   return (
     <Grid as="header" className="cs--common-header">
-      <Column sm={4} md={8} lg={8}>
-        <AspectRatio as="section" ratio="16x9">
+      <Column sm={4} md={8} lg={16}>
+        <div className="cs--common-header__content">
           <Heading className="cs--common-header__title">{title}</Heading>
-          {paragraphs.map((paragraph, i) => (
-            <p key={`common-header-paragraph-${i}`}>{paragraph}</p>
-          ))}
-        </AspectRatio>
-      </Column>
-      <Column sm={4} md={8} lg={8}>
-        <AspectRatio ratio="16x9" className="cs--common-header__image-banner">
-          <img
-            src="/icon.dark.svg?version=0.1.0"
-            className="cs--common-header__logo"
-            alt="fed-at-ibm logo"
-          />
-        </AspectRatio>
+          <div className="cs--common-header__other">
+            {paragraphs.map((paragraph, i) => (
+              <p key={`common-header-paragraph-${i}`}>{paragraph}</p>
+            ))}
+          </div>
+          <div className="cs--common-header__image-banner">
+            <img
+              src="/icon.dark.svg?version=0.1.0"
+              className="cs--common-header__logo"
+              alt="fed-at-ibm logo"
+            />
+          </div>
+        </div>
       </Column>
     </Grid>
   );

--- a/src/components/commonHeader/commonHeader.scss
+++ b/src/components/commonHeader/commonHeader.scss
@@ -20,6 +20,8 @@
   display: grid;
   grid-template-areas: 'title title' 'other other' 'image image';
   grid-template-columns: 1fr 1fr;
+  /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties -- need to control size of rows and columns */
+  grid-template-rows: auto 1fr;
 
   @include breakpoint(md) {
     grid-template-areas: 'title title' 'other image';

--- a/src/components/commonHeader/commonHeader.scss
+++ b/src/components/commonHeader/commonHeader.scss
@@ -8,20 +8,57 @@
 @use '@carbon/react/scss/spacing' as *;
 @use '@carbon/react/scss/type' as *;
 @use '@carbon/react/scss/theme' as *;
+@use '@carbon/react/scss/breakpoint' as *;
 
 .cs--common-header {
+  position: relative;
   margin-block-end: $spacing-09;
 }
 
+.cs--common-header__content {
+  // This CSS follow the principles of a condensed carbon grid with 2x2
+  display: grid;
+  grid-template-areas: 'title title' 'other other' 'image image';
+  grid-template-columns: 1fr 1fr;
+
+  @include breakpoint(md) {
+    grid-template-areas: 'title title' 'other image';
+  }
+
+  @include breakpoint(lg) {
+    grid-template-areas: 'title image' 'other image';
+  }
+}
+
+.cs--common-header__title {
+  grid-area: title;
+}
+
+.cs--common-header__other {
+  grid-area: other;
+}
+
 .cs--common-header__image-banner {
+  grid-area: image;
   display: flex;
+  inline-size: 100%;
+
+  // 414px is the maximum height seen in the previous layout
+  max-inline-size: min(100%, 414px);
+  aspect-ratio: 1/1;
+  margin-inline: auto;
   align-items: center;
   justify-content: center;
   background: radial-gradient(
-    circle,
-    var(--cs-brand-alt) 20%,
-    rgb(0 0 0 / 0%) 50%
+    closest-side,
+    var(--cs-brand-alt) 40%,
+    rgb(0 0 0 / 0%) 100%
   );
+
+  @include breakpoint-between(md, lg) {
+    /* stylelint-disable-next-line carbon/layout-use  -- this reduces the height of the headed without impacting on the title */
+    margin-block-start: max(-16%, calc(-1 * #{$spacing-10}));
+  }
 }
 
 .cs--common-header__logo {


### PR DESCRIPTION
Fixes #374 

Headers with images to one side are often tricky to produce neatly within a formal column layout system as defined by Carbon.

This PR hosts the whole header in a single column and uses CSS directly, following the spirit of Carbon, to provide a more pleasing responsive behaviour. The aspect ratio was also not providing us with any benefit on narrower screens as the content, constrained by width, grew taller than the ratio.

##Before large
<img width="1705" height="544" alt="image" src="https://github.com/user-attachments/assets/a48f601c-e81a-4bfd-9ebe-6683fb216595" />

## After large
<img width="896" height="262" alt="image" src="https://github.com/user-attachments/assets/0818304a-fd7e-4f5d-aec4-d7d209dd7cb1" />

## Before 1057px
<img width="645" height="273" alt="image" src="https://github.com/user-attachments/assets/6f9a2259-4377-4ef1-b72f-94b3f7875028" />

## After 1057px
<img width="594" height="263" alt="image" src="https://github.com/user-attachments/assets/178f614a-6289-4288-8c17-cad955eb6b23" />

## Before 1055px
<img width="558" height="483" alt="image" src="https://github.com/user-attachments/assets/94a7622b-11cd-44e2-a3a1-028c23556791" />

## After 1055px
<img width="534" height="294" alt="image" src="https://github.com/user-attachments/assets/fe070891-68cf-4d96-98e9-89941e04c1af" />

## Before 672px
<img width="343" height="477" alt="image" src="https://github.com/user-attachments/assets/46491973-72d1-4882-abb9-29030989ecc7" />

## After 672px
<img width="354" height="280" alt="image" src="https://github.com/user-attachments/assets/65933142-1946-4968-949d-24dbae21475a" />

## Before 640px
<img width="334" height="390" alt="image" src="https://github.com/user-attachments/assets/13aac7d7-af6f-4461-901f-ec9d7c406004" />

## After 640px
<img width="347" height="436" alt="image" src="https://github.com/user-attachments/assets/1daded02-21ea-4fe9-800a-4189154eae5a" />

## Before 320px
<img width="332" height="1051" alt="image" src="https://github.com/user-attachments/assets/7538f2cd-d1e0-4ddf-8ba7-3b256d3b3347" />

## After 320px
<img width="332" height="1029" alt="image" src="https://github.com/user-attachments/assets/75aa0f36-8e87-40f8-aa97-470cac5d26e8" />

