### PR TITLE
chore: use PageLayout.Header on all pages

### DIFF
--- a/src/components/commonHeader/commonHeader.scss
+++ b/src/components/commonHeader/commonHeader.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,6 +17,7 @@
   grid-template-columns: 1fr 1fr;
   /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties -- need to control size of rows and columns */
   grid-template-rows: auto 1fr;
+  padding-block-start: $spacing-05;
 
   @include breakpoint(md) {
     grid-template-areas: 'title title' 'other image';

--- a/src/layouts/page-layout.jsx
+++ b/src/layouts/page-layout.jsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,6 +9,34 @@ import { Content } from '@carbon/react';
 import { Children, Suspense } from 'react';
 import { Nav } from '../components/nav/Nav';
 import classNames from 'classnames';
+
+/**
+ * PageLayout component provides a consistent layout structure for pages in the application.
+ * It includes the navigation component and wraps content in Carbon's Content component.
+ *
+ * @component
+ * @param {Object} props - Component props
+ * @param {React.ReactNode} props.children - Child components to render within the layout
+ * @param {string} [props.className] - Additional CSS class names to apply to the layout container
+ * @param {React.ReactNode} [props.fallback] - Fallback content to display while Suspense is loading
+ *
+ * @example
+ * // Basic usage
+ * <PageLayout>
+ *   <h1>Page Content</h1>
+ * </PageLayout>
+ *
+ * @example
+ * // With PageLayout.Header for flush header positioning
+ * // The Header component allows the page header to sit flush against the global header,
+ * // which is useful for headers with non-transparent backgrounds (like PageHeader from @carbon/ibm-products)
+ * <PageLayout className="my-page" fallback={<p>Loading...</p>}>
+ *   <PageLayout.Header>
+ *     <PageHeader title="Dashboard" />
+ *   </PageLayout.Header>
+ *   <div>Main content here</div>
+ * </PageLayout>
+ */
 
 export const PageLayout = ({ children, className, fallback }) => {
   const childArray = Children.toArray(children);
@@ -31,9 +59,28 @@ export const PageLayout = ({ children, className, fallback }) => {
     </Suspense>
   );
 };
-
+/**
+ * PageLayout.Header component for page headers that need to sit flush against the global header.
+ *
+ * This component is useful when using headers with non-transparent backgrounds (such as
+ * PageHeader from @carbon/ibm-products) as it removes the default spacing and allows the
+ * header to align directly with the global navigation header.
+ *
+ * @component
+ * @param {Object} props - Component props
+ * @param {React.ReactNode} props.children - Header content (typically a PageHeader component)
+ *
+ * @example
+ * <PageLayout>
+ *   <PageLayout.Header>
+ *     <PageHeader title="Dashboard" />
+ *   </PageLayout.Header>
+ *   <div>Page content</div>
+ * </PageLayout>
+ */
 const PageLayoutHeader = ({ children }) => (
   <div className="cs--page-layout__content-header">{children}</div>
 );
+
 PageLayoutHeader.displayName = 'PageLayoutHeader';
 PageLayout.Header = PageLayoutHeader;

--- a/src/pages/not-found/NotFound.jsx
+++ b/src/pages/not-found/NotFound.jsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,17 +16,19 @@ const NotFound = () => {
       className="cs--not-found"
       fallback={<p>Loading not found page...</p>}
     >
-      <CommonHeader
-        title={'Page not found'}
-        paragraphs={[
-          <>This is not the page you were looking for.</>,
-          <>
-            The route <em>&lsquo;{location.pathname}&rsquo;</em> is not
-            recognized.
-          </>,
-          <>Maintained by fed-at-ibm, a chapter of the OIC.</>,
-        ]}
-      />
+      <PageLayout.Header>
+        <CommonHeader
+          title={'Page not found'}
+          paragraphs={[
+            <>This is not the page you were looking for.</>,
+            <>
+              The route <em>&lsquo;{location.pathname}&rsquo;</em> is not
+              recognized.
+            </>,
+            <>Maintained by fed-at-ibm, a chapter of the OIC.</>,
+          ]}
+        />
+      </PageLayout.Header>
     </PageLayout>
   );
 };

--- a/src/pages/placeholder/Placeholder.jsx
+++ b/src/pages/placeholder/Placeholder.jsx
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,18 +17,20 @@ const Placeholder = () => {
       className="cs--placeholder"
       fallback={<p>Loading placeholder page...</p>}
     >
-      <CommonHeader
-        title={'This page is not ready yet'}
-        paragraphs={[
-          <>Generally not a good idea to have pages under construction.</>,
-          <>This page is here to help demonstrate the global navigation.</>,
-          <>
-            You are at the location served from route{' '}
-            <em>&lsquo;{location.pathname}&rsquo;</em>.
-          </>,
-          <>Maintained by fed-at-ibm, a chapter of the OIC.</>,
-        ]}
-      />
+      <PageLayout.Header>
+        <CommonHeader
+          title={'This page is not ready yet'}
+          paragraphs={[
+            <>Generally not a good idea to have pages under construction.</>,
+            <>This page is here to help demonstrate the global navigation.</>,
+            <>
+              You are at the location served from route{' '}
+              <em>&lsquo;{location.pathname}&rsquo;</em>.
+            </>,
+            <>Maintained by fed-at-ibm, a chapter of the OIC.</>,
+          ]}
+        />
+      </PageLayout.Header>
     </PageLayout>
   );
 };

--- a/src/pages/welcome/Welcome.jsx
+++ b/src/pages/welcome/Welcome.jsx
@@ -23,7 +23,9 @@ const Welcome = () => {
       className="cs--welcome"
       fallback={<p>Loading welcome page...</p>}
     >
-      <WelcomeHeader />
+      <PageLayout.Header>
+        <WelcomeHeader />
+      </PageLayout.Header>
 
       <WelcomeRunSection />
 


### PR DESCRIPTION
So in PageLayout there is a PageLayout.Header component. It's only purpose is to provide PageLayout with the opportunity to not add padding at the top of every page. 

I"m going to pen an alternative without it for comparison.