### PR TITLE
fix: addresses concerns in issue 309

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "type": "module",
   "scripts": {
     "dev": "node src/server",
-    "build": "npm run build:client && npm run build:server",
-    "build:client": "vite build --ssrManifest .vite/ssr-manifest.json  --outDir dist/client",
-    "build:server": "vite build --ssr src/entry-server.jsx --outDir dist/server",
+    "build": "cross-env NODE_ENV=production npm run build:client && npm run build:server",
+    "build:client": "cross-env NODE_ENV=production vite build --ssrManifest .vite/ssr-manifest.json  --outDir dist/client",
+    "build:server": "cross-env NODE_ENV=production vite build --ssr src/entry-server.jsx --outDir dist/server",
     "lighthouse": "lhci collect",
     "lint": "npm run lint:es && npm run lint:style && npm run lint:format && npm run lint:spell",
     "lint-fix": "npm run lint:es -- --fix && npm run lint:style -- --fix && npm run lint:format",


### PR DESCRIPTION
## Summary
Explicitly set NODE_ENV=production for build scripts to prevent potential environment-related issues and follow best practices.

## Related Issue
Closes #309

## Changes
Updated package.json build scripts to use cross-env NODE_ENV=production:

build
build:client
build:server

## Context
Issue #309 reported a jsxDEV is not a function error when developers had NODE_ENV=dev set in their environment before running builds. While this issue appears to have been resolved through the upgrade to @vitejs/plugin-react-swc and React 19 (which handle JSX transformation more robustly), explicitly setting NODE_ENV=production for build scripts is still beneficial as:

## Best practice - Production builds should always run with NODE_ENV=production
Future-proofing - Protects against potential regressions if dependencies change
Consistency - Matches the pattern already used in the preview:prod script
Performance - Ensures all optimizations are applied (minification, dead code elimination, etc.)
Clear intent - Makes it explicit that builds should run in production mode
Testing
Verified that builds work correctly with and without NODE_ENV set in the environment:

NODE_ENV=DEV npm run build
npm run preview:prod

No errors occur, and the application runs as expected.