### PR TITLE
fix: blog review changes

### DIFF
--- a/cspell-dictionaries/project.txt
+++ b/cspell-dictionaries/project.txt
@@ -9,3 +9,4 @@ Stephane
 Testbarkeit
 fouc
 vite
+nojekyll

--- a/src/components/profilePanel/ProfilePanel.jsx
+++ b/src/components/profilePanel/ProfilePanel.jsx
@@ -19,8 +19,8 @@ import {
 import { useTranslation } from 'react-i18next';
 import {
   getThemeSettings,
-  setThemeSetting as updateThemeSetting,
-  setHeaderInverse as updateHeaderInverse,
+  setThemeSetting,
+  setHeaderInverse,
 } from '../../utils/theme';
 
 export const ProfilePanel = ({ className }) => {
@@ -29,24 +29,24 @@ export const ProfilePanel = ({ className }) => {
   // Get initial values from cookies (single call to avoid redundant parsing)
   const initialSettings = getThemeSettings();
 
-  const [themeSetting, setThemeSettingState] = useState(
+  const [themeSettingLocal, setThemeSettingLocal] = useState(
     initialSettings.themeSetting,
   );
 
-  const [themeMenuComplement, setThemeMenuComplementState] = useState(
+  const [themeMenuComplementLocal, setThemeMenuComplementLocal] = useState(
     initialSettings.headerInverse,
   );
 
   // Update theme setting
   const handleThemeSettingChange = (value) => {
-    setThemeSettingState(value);
-    updateThemeSetting(value);
+    setThemeSettingLocal(value);
+    setThemeSetting(value);
   };
 
   // Update header inverse
   const handleThemeMenuComplementChange = (value) => {
-    setThemeMenuComplementState(value);
-    updateHeaderInverse(value);
+    setThemeMenuComplementLocal(value);
+    setHeaderInverse(value);
   };
 
   const userProfile = {
@@ -75,7 +75,7 @@ export const ProfilePanel = ({ className }) => {
         <ThemeSettings>
           <ThemeSwitcher
             onChange={handleThemeSettingChange}
-            value={themeSetting}
+            value={themeSettingLocal}
           ></ThemeSwitcher>
           <ThemeMenuComplement
             id="theme-menu-complement"
@@ -83,7 +83,7 @@ export const ProfilePanel = ({ className }) => {
               'profile.settings.complementMenuTheme',
               'Complement menu theme',
             )}
-            checked={themeMenuComplement}
+            checked={themeMenuComplementLocal}
             onChange={handleThemeMenuComplementChange}
           />
         </ThemeSettings>

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -50,6 +50,13 @@ export function setHeaderInverse(headerInverse) {
  * Initialize theme on page load (sync HTML attributes with cookies)
  * Call this once when the app starts
  * Only updates attributes if they're not already set by SSR
+ *
+ * > [!WARNING] **Hydration Mismatch Prevention**
+ * > The `initializeTheme` function deliberately avoids updating attributes if
+ * > they differ from cookie values. This prevents React hydration errors when
+ * > cookies change between SSR and client-side hydration. The warning messages
+ * > help developers identify when this occurs, and the changes will take effect
+ * > on the next page navigation.
  */
 export function initializeTheme() {
   if (typeof document === 'undefined') return;


### PR DESCRIPTION
When writing a blog about theming, a review suggested adding notes about SSR hydration and using setThemeSettings consistently, instead of renaming to updateThemeSettings.

No functional change made.