### PR TITLE
fix: add missing conventional-changelog-conventionalcommits dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "carbon-react-starter",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "carbon-react-starter",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0",
       "dependencies": {
         "@carbon-labs/react-theme-settings": "^0.30.0",
         "@carbon/ibm-products": "^2.74.0",
@@ -44,6 +44,7 @@
         "@vitejs/plugin-react": "^6.0.0",
         "@vitest/coverage-v8": "^4.0.0",
         "baseline-browser-mapping": "^2.9.12",
+        "conventional-changelog-conventionalcommits": "^10.2.0",
         "cross-env": "^10.0.0",
         "cspell": "^10.0.0",
         "detect-port": "^2.1.0",
@@ -849,6 +850,16 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@conventional-changelog/template": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.0.tgz",
+      "integrity": "sha512-12qHxvlKjHmP0PQ+17EREgC7lWyLwbph1RKcZQZ7k7ZWGmrxfxC9gadHGfvzr0g0u8BhiBGg3tks93txodlyRQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
@@ -7067,6 +7078,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.0.tgz",
+      "integrity": "sha512-UtlM9GqolY7OmlQh5L/UEVoKsTUpTgUVy1PU8JN5gl5Ydaejb7WRklGliG1SKPxxj7hzA173eG3Kt5fYWE2pmg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@vitejs/plugin-react": "^6.0.0",
     "@vitest/coverage-v8": "^4.0.0",
     "baseline-browser-mapping": "^2.9.12",
+    "conventional-changelog-conventionalcommits": "^10.2.0",
     "cross-env": "^10.0.0",
     "cspell": "^10.0.0",
     "detect-port": "^2.1.0",


### PR DESCRIPTION
The release workflow was failing with `Cannot find module 'conventional-changelog-conventionalcommits'`. This package is a required peer dependency of `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` when using the `conventionalcommits` preset, but it was not explicitly installed.

Closes the release failure introduced after merging #688.