### PR TITLE
fix: remove @semantic-release/git plugin incompatible with branch protection

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -71,13 +71,6 @@
         "npmPublish": false
       }
     ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
The release workflow was failing because `@semantic-release/git` tries to push a release commit (with the bumped `package.json` and `CHANGELOG.md`) directly to `main`, which is blocked by branch protection rules.

**Fix:** remove the `@semantic-release/git` plugin. The GitHub release, tag, and changelog file are still created correctly by `@semantic-release/changelog` and `@semantic-release/github`.

**Tested:** pushed to `alpha` branch and confirmed `v1.0.0-alpha.1` was published successfully.