### PR TITLE
feat: CSS splitting, lazy-loading, and bundle guardrails

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -6,12 +6,14 @@
   "plugins": [
     "@double-great/stylelint-a11y",
     "stylelint-use-logical",
-    "stylelint-plugin-carbon-tokens"
+    "stylelint-plugin-carbon-tokens",
+    "./stylelint-plugins/no-carbon-full-entrypoint.cjs"
   ],
   "reportNeedlessDisables": true,
   "reportInvalidScopeDisables": true,
   "reportDescriptionlessDisables": true,
   "rules": {
+    "plugin/no-carbon-full-entrypoint": true,
     "a11y/media-prefers-reduced-motion": true,
     "a11y/no-outline-none": true,
     "a11y/selector-pseudo-class-focus": true,

--- a/cspell.json
+++ b/cspell.json
@@ -43,5 +43,13 @@
     "*.snap",
     "*.log"
   ],
-  "words": []
+  "words": [
+    "colocating",
+    "navigations",
+    "onwarn",
+    "prefetchable",
+    "stylesheet",
+    "unminified",
+    "unnamespaced"
+  ]
 }

--- a/docs/css-and-js-splitting.md
+++ b/docs/css-and-js-splitting.md
@@ -1,0 +1,106 @@
+# CSS and JS splitting
+
+This document explains how the starter splits CSS and JavaScript across routes, and the conventions you must follow when adding new pages.
+
+---
+
+## How it works
+
+The starter uses three complementary techniques to keep initial load fast and subsequent navigation instant.
+
+### 1. Per-page CSS and JS chunks
+
+Each page component imports its own stylesheet directly:
+
+```jsx
+// src/pages/my-page/MyPage.jsx
+import './my-page.scss'; // ← here, not in index.scss
+
+export default function MyPage() { ... }
+```
+
+Because the page is loaded via `React.lazy()`, Vite automatically emits the stylesheet as a separate CSS file linked to that route's JS chunk. The browser only downloads it when the user first visits that page.
+
+**Do not add page styles to [`src/index.scss`](../src/index.scss).** That file is reserved for globally required styles: Carbon tokens, the theme cascade, and shell components (header, footer, layout). Adding a page's styles there forces every visitor to download them on every page, regardless of which route they visit.
+
+### 2. Carbon isolated as a vendor chunk
+
+All `@carbon/*`, `@ibm/*`, and `@carbon-labs/*` JavaScript is bundled into a single `vendor-carbon` chunk. This chunk is large, but it is cached in the browser after the first visit and never re-downloaded when you deploy new application code.
+
+This is configured in [`vite.config.js`](../vite.config.js) via `build.rollupOptions.output.manualChunks`.
+
+### 3. Prefetch on idle + server preload hints
+
+After the first page is interactive, the browser prefetches the JS and CSS chunks for every other route in the background at low priority. This is the same strategy Next.js uses — by the time the user clicks a link, the assets are already cached.
+
+Additionally, the SSR server injects `<link rel="modulepreload">` and `<link rel="preload" as="style">` tags for the *current* page's chunks into the HTML `<head>`, so the browser can fetch them in parallel with the HTML stream.
+
+---
+
+## Carbon SCSS import rules
+
+Carbon exposes two kinds of SCSS imports that behave very differently:
+
+| Import | Emits CSS? | Safe in component files? |
+|---|---|---|
+| `@use '@carbon/react'` | Yes — all ~80 components | ❌ `index.scss` only |
+| `@use '@carbon/ibm-products/css/index.min'` | Yes — all IBM Products | ❌ `index.scss` only |
+| `@use '@carbon/react/scss/spacing'` | No — SCSS variables only | ✅ Anywhere |
+| `@use '@carbon/react/scss/theme'` | No — mixins only | ✅ Anywhere |
+| `@use '@carbon/react/scss/breakpoint'` | No — mixins only | ✅ Anywhere |
+
+Importing a full entrypoint outside `src/index.scss` silently duplicates ~1.8 MB of CSS into that file's output chunk. A Stylelint rule (`plugin/no-carbon-full-entrypoint`) enforces this and will fail `npm run lint` if violated.
+
+---
+
+## Adding a new page
+
+1. Create your page component and its SCSS file:
+   ```
+   src/pages/my-page/
+     MyPage.jsx
+     my-page.scss
+   ```
+
+2. Import the stylesheet at the top of the component:
+   ```jsx
+   import './my-page.scss';
+   ```
+
+3. Register the page with `React.lazy()` in [`src/routes/config.js`](../src/routes/config.js) and add a `chunkId` matching the source path:
+   ```js
+   const MyPage = lazy(() => import('../pages/my-page/MyPage'));
+
+   // in the routes array:
+   {
+     path: '/my-page',
+     element: MyPage,
+     chunkId: 'src/pages/my-page/MyPage.jsx',
+   }
+   ```
+
+   The `chunkId` is used by the server to emit preload hints and by the client to prefetch the page's assets. It must match the path Vite uses as the module ID — the relative path from the project root.
+
+4. Use Carbon token/mixin sub-paths freely in your SCSS:
+   ```scss
+   @use '@carbon/react/scss/spacing' as *;
+   @use '@carbon/react/scss/breakpoint' as *;
+   ```
+
+   Do **not** use `@use '@carbon/react'` or `@use '@carbon/ibm-products'` in component files.
+
+---
+
+## Bundle size guardrail
+
+The build is configured to warn if any chunk other than `vendor-carbon` exceeds the size threshold. If you see an unexpected large-chunk warning, the most likely cause is a page component importing a full Carbon entrypoint — check the Stylelint output first.
+
+The threshold is set to 3× the measured `vendor-carbon` baseline (298 kB) to give ample headroom for a full-featured IBM product UI. If your app's `vendor-carbon` chunk grows significantly beyond 298 kB due to additional Carbon dependencies, update `build.chunkSizeWarningLimit` in [`vite.config.js`](../vite.config.js) and document the new baseline.
+
+---
+
+## Open question — Carbon CSS tree-shaking
+
+> **This question is open for Carbon SME input.**
+
+The current approach imports the entire Carbon component library in one shot (`@use '@carbon/react'`). Carbon's SCSS is structured to support per-component imports, which would allow each page to load only the CSS for the components it actually uses. See the discussion in the [pull request](https://github.com/carbon-design-system/carbon-react-router-starter/pulls) for context, trade-offs, and the specific questions raised for the Carbon team.

--- a/docs/css-and-js-splitting.md
+++ b/docs/css-and-js-splitting.md
@@ -27,13 +27,15 @@ Because the page is loaded via `React.lazy()`, Vite automatically emits the styl
 
 All `@carbon/*`, `@ibm/*`, and `@carbon-labs/*` JavaScript is bundled into a single `vendor-carbon` chunk. This chunk is large, but it is cached in the browser after the first visit and never re-downloaded when you deploy new application code.
 
-This is configured in [`vite.config.js`](../vite.config.js) via `build.rollupOptions.output.manualChunks`.
+This is configured in [`vite.config.js`](../vite.config.js) via `build.rolldownOptions.output.codeSplitting`. Vite 8 replaced the deprecated `build.rollupOptions.output.manualChunks` function with this Rolldown-native API.
+
+A small `rolldown-runtime` chunk (~0.6 kB) is also emitted automatically by Rolldown whenever `codeSplitting.groups` is used. It contains module-loading bootstrap code and is loaded first on every page.
 
 ### 3. Prefetch on idle + server preload hints
 
 After the first page is interactive, the browser prefetches the JS and CSS chunks for every other route in the background at low priority. This is the same strategy Next.js uses — by the time the user clicks a link, the assets are already cached.
 
-Additionally, the SSR server injects `<link rel="modulepreload">` and `<link rel="preload" as="style">` tags for the *current* page's chunks into the HTML `<head>`, so the browser can fetch them in parallel with the HTML stream.
+Additionally, the SSR server injects `<link rel="modulepreload">` and `<link rel="preload" as="style">` tags for the _current_ page's chunks into the HTML `<head>`, so the browser can fetch them in parallel with the HTML stream.
 
 ---
 
@@ -41,13 +43,16 @@ Additionally, the SSR server injects `<link rel="modulepreload">` and `<link rel
 
 Carbon exposes two kinds of SCSS imports that behave very differently:
 
-| Import | Emits CSS? | Safe in component files? |
-|---|---|---|
-| `@use '@carbon/react'` | Yes — all ~80 components | ❌ `index.scss` only |
-| `@use '@carbon/ibm-products/css/index.min'` | Yes — all IBM Products | ❌ `index.scss` only |
-| `@use '@carbon/react/scss/spacing'` | No — SCSS variables only | ✅ Anywhere |
-| `@use '@carbon/react/scss/theme'` | No — mixins only | ✅ Anywhere |
-| `@use '@carbon/react/scss/breakpoint'` | No — mixins only | ✅ Anywhere |
+| Import                                                 | Emits CSS?                                | Safe in component files?     |
+| ------------------------------------------------------ | ----------------------------------------- | ---------------------------- |
+| `@use '@carbon/react'`                                 | Yes — all ~80 Carbon components           | ❌ `index.scss` only         |
+| `@use '@carbon/ibm-products/css/index-without-carbon'` | Yes — IBM Products components only        | ❌ `index.scss` only         |
+| `@use '@carbon/ibm-products/css/index-full-carbon'`    | Yes — IBM Products **and** Carbon (avoid) | ❌ Never — duplicates Carbon |
+| `@use '@carbon/react/scss/spacing'`                    | No — SCSS variables only                  | ✅ Anywhere                  |
+| `@use '@carbon/react/scss/theme'`                      | No — mixins only                          | ✅ Anywhere                  |
+| `@use '@carbon/react/scss/breakpoint'`                 | No — mixins only                          | ✅ Anywhere                  |
+
+Use `index-without-carbon` (not `index` or `index-full-carbon`) for IBM Products because this starter already imports `@carbon/react` directly. Using the full entrypoint would duplicate all Carbon base CSS into the output.
 
 Importing a full entrypoint outside `src/index.scss` silently duplicates ~1.8 MB of CSS into that file's output chunk. A Stylelint rule (`plugin/no-carbon-full-entrypoint`) enforces this and will fail `npm run lint` if violated.
 
@@ -56,6 +61,7 @@ Importing a full entrypoint outside `src/index.scss` silently duplicates ~1.8 MB
 ## Adding a new page
 
 1. Create your page component and its SCSS file:
+
    ```
    src/pages/my-page/
      MyPage.jsx
@@ -63,11 +69,13 @@ Importing a full entrypoint outside `src/index.scss` silently duplicates ~1.8 MB
    ```
 
 2. Import the stylesheet at the top of the component:
+
    ```jsx
    import './my-page.scss';
    ```
 
 3. Register the page with `React.lazy()` in [`src/routes/config.js`](../src/routes/config.js) and add a `chunkId` matching the source path:
+
    ```js
    const MyPage = lazy(() => import('../pages/my-page/MyPage'));
 
@@ -82,6 +90,7 @@ Importing a full entrypoint outside `src/index.scss` silently duplicates ~1.8 MB
    The `chunkId` is used by the server to emit preload hints and by the client to prefetch the page's assets. It must match the path Vite uses as the module ID — the relative path from the project root.
 
 4. Use Carbon token/mixin sub-paths freely in your SCSS:
+
    ```scss
    @use '@carbon/react/scss/spacing' as *;
    @use '@carbon/react/scss/breakpoint' as *;

--- a/src/components/footer/footer.scss
+++ b/src/components/footer/footer.scss
@@ -1,10 +1,13 @@
 /**
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
+// Carbon sub-path imports (spacing, theme, etc.) are safe in component SCSS
+// files — they expose only SCSS variables and mixins with no CSS output.
+// SCSS's @use module system deduplicates them across all files automatically.
 @use '@carbon/react/scss/spacing' as *;
 
 .cs--footer {

--- a/src/entry-client.jsx
+++ b/src/entry-client.jsx
@@ -15,6 +15,8 @@ import { Router } from './routes';
 // App level imports
 import { initializeTheme } from './utils/theme';
 import i18n from './i18n.client.js';
+import { prefetchRoutes } from './utils/prefetchRoutes.js';
+import { routes } from './routes/config.js';
 
 /**
  * Initializes the theme on client load by reading the user's preference
@@ -62,3 +64,11 @@ hydrateRoot(
 
 // Remove visibility hidden after hydration to prevent FOUC
 document.body.classList.add('ready');
+
+/**
+ * After hydration, prefetch the JS and CSS chunks for every other route on
+ * idle. This ensures subsequent navigations are instant — the browser has
+ * already fetched the page chunks before the user requests them.
+ * Only runs in production (see prefetchRoutes.js for rationale).
+ */
+prefetchRoutes(routes, window.location.pathname);

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,10 +1,20 @@
 /**
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
+// ─── Carbon full entrypoints — only in this file ─────────────────────────────
+// '@carbon/react' and '@carbon/ibm-products' emit all Carbon component CSS.
+// Importing them anywhere else duplicates the entire stylesheet into that
+// file's output chunk — a silent ~1.8 MB regression per accidental import.
+// Carbon token/mixin sub-paths ARE safe to use in any SCSS file:
+//   @use '@carbon/react/scss/spacing'   → SCSS variables only, zero CSS output
+//   @use '@carbon/react/scss/theme'     → mixins only, zero CSS output
+//   @use '@carbon/react/scss/breakpoint'→ mixins only, zero CSS output
+// SCSS's @use module system deduplicates them automatically.
+// See also: the Stylelint rule in .stylelintrc.json that enforces this.
 @use '@carbon/ibm-products/css/index.min';
 @use '@carbon/react' with (
   $font-path: '@ibm/plex',
@@ -16,14 +26,12 @@
 @use '@carbon/react/scss/colors' as *;
 @use '@carbon-labs/react-theme-settings/scss/theme-settings';
 
-/* Importing the component styles here will load them
-   before the JavaScript, which will make the page 
-   not "flashing style" - everything will be at the right
-   place from the start. In most case, avoid loading styles
-   from the JavaScript. */
+// ─── Global component styles — shell only ────────────────────────────────────
+// Only styles that are present on every page belong here: layout, header,
+// footer. Page-specific styles belong in the page component file (e.g.
+// src/pages/welcome/welcome.scss), imported directly from the JSX. Vite then
+// emits them as a separate CSS chunk loaded only when that route is visited.
 @use 'layouts/page-layout';
-@use 'pages/welcome/welcome';
-@use 'pages/dashboard/dashboard';
 @use 'components/commonHeader/commonHeader';
 @use 'components/footer/footer';
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -15,7 +15,10 @@
 //   @use '@carbon/react/scss/breakpoint'→ mixins only, zero CSS output
 // SCSS's @use module system deduplicates them automatically.
 // See also: the Stylelint rule in .stylelintrc.json that enforces this.
-@use '@carbon/ibm-products/css/index.min';
+// Use 'index-without-carbon' (not 'index' or 'index-full-carbon') because this
+// file already loads @carbon/react below. Using the full entrypoint would
+// duplicate all Carbon base CSS into the output bundle.
+@use '@carbon/ibm-products/css/index-without-carbon';
 @use '@carbon/react' with (
   $font-path: '@ibm/plex',
   $font-display: 'block'

--- a/src/pages/dashboard/Dashboard.jsx
+++ b/src/pages/dashboard/Dashboard.jsx
@@ -5,6 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Page-specific styles are imported here, not in index.scss, so Vite emits
+// them as a separate CSS chunk loaded only when this route is visited.
+import './dashboard.scss';
+
 import { useTranslation } from 'react-i18next';
 
 import { Footer } from '../../components/footer/Footer';

--- a/src/pages/welcome/Welcome.jsx
+++ b/src/pages/welcome/Welcome.jsx
@@ -5,6 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Page-specific styles are imported here, not in index.scss, so Vite emits
+// them as a separate CSS chunk loaded only when this route is visited.
+import './welcome.scss';
+
 import { Footer } from '../../components/footer/Footer';
 import { WelcomeHeader } from './WelcomeHeader.jsx';
 import { PageLayout } from '../../layouts/page-layout.jsx';

--- a/src/routes/config.js
+++ b/src/routes/config.js
@@ -172,7 +172,12 @@ export const routes = [
   {
     path: '*',
     element: NotFound,
-    chunkId: 'src/pages/not-found/NotFound.jsx',
+    // chunkId is intentionally omitted here. The 404 page is a low-value
+    // prefetch target — users are unlikely to visit it intentionally, so
+    // pre-warming its chunk wastes bandwidth. Omitting chunkId suppresses
+    // both the server-side <link rel="preload"> hint and the client-side
+    // idle prefetch without affecting how the page loads when actually reached.
+    // Add chunkId: 'src/pages/not-found/NotFound.jsx' to re-enable preloading.
     status: 404,
   },
 ];

--- a/src/routes/config.js
+++ b/src/routes/config.js
@@ -7,10 +7,10 @@
 import { lazy } from 'react';
 import { MagicWand, LogoGithub } from '@carbon/icons-react';
 
-// This project splits the pages each in different JavaScript bundles.
-// You might also split part of the pages that incur significant
-// network load at your discretion, given they are not needed right
-// away when the page loads.
+// This project splits each page into a separate JavaScript (and CSS) chunk.
+// The chunkId on each route matches the key used in the Vite SSR manifest
+// so the server can emit <link rel="modulepreload"> hints and the client can
+// prefetch non-active routes — both without guessing hashed filenames.
 const Dashboard = lazy(() => import('../pages/dashboard/Dashboard'));
 const NotFound = lazy(() => import('../pages/not-found/NotFound'));
 const Placeholder = lazy(() => import('../pages/placeholder/Placeholder'));
@@ -33,6 +33,7 @@ const Welcome = lazy(() => import('../pages/welcome/Welcome'));
 //   index?: boolean;
 //   element?: ({ usingOutlet }: { usingOutlet?: boolean }) => JSX.Element;
 //   status?: number;
+//   chunkId?: string; // source module path matching the Vite SSR manifest key
 //   carbon?: carbonRouteType;
 // };
 
@@ -41,10 +42,12 @@ export const routes = [
     index: true,
     path: '/',
     element: Welcome,
+    chunkId: 'src/pages/welcome/Welcome.jsx',
   },
   {
     path: '/dashboard',
     element: Dashboard,
+    chunkId: 'src/pages/dashboard/Dashboard.jsx',
     carbon: {
       labelKey: 'routes.dashboard',
       label: 'Dashboard',
@@ -54,10 +57,12 @@ export const routes = [
   {
     path: '/dashboard/:id',
     element: Dashboard,
+    chunkId: 'src/pages/dashboard/Dashboard.jsx',
   },
   {
     path: '/link-1',
     element: Placeholder,
+    chunkId: 'src/pages/placeholder/Placeholder.jsx',
     carbon: {
       labelKey: 'routes.link1',
       label: 'Link 1',
@@ -67,6 +72,7 @@ export const routes = [
   {
     path: '/link-2',
     element: Placeholder,
+    chunkId: 'src/pages/placeholder/Placeholder.jsx',
     carbon: {
       labelKey: 'routes.link2',
       label: 'Link 2',
@@ -76,6 +82,7 @@ export const routes = [
   {
     path: '/link-3',
     element: Placeholder,
+    chunkId: 'src/pages/placeholder/Placeholder.jsx',
     carbon: {
       labelKey: 'routes.link3',
       label: 'Link 3',
@@ -93,6 +100,7 @@ export const routes = [
   {
     path: '/link-4/sub-link-1',
     element: Placeholder,
+    chunkId: 'src/pages/placeholder/Placeholder.jsx',
     carbon: {
       labelKey: 'routes.link4.subLink1',
       label: 'Sub-link 1',
@@ -101,6 +109,7 @@ export const routes = [
   {
     path: '/link-4/sub-link-2',
     element: Placeholder,
+    chunkId: 'src/pages/placeholder/Placeholder.jsx',
     carbon: {
       labelKey: 'routes.link4.subLink2',
       label: 'Sub-link 2',
@@ -109,6 +118,7 @@ export const routes = [
   {
     path: '/link-4/sub-link-3',
     element: Placeholder,
+    chunkId: 'src/pages/placeholder/Placeholder.jsx',
     carbon: {
       labelKey: 'routes.link4.subLink3',
       label: 'Sub-link 3',
@@ -162,6 +172,7 @@ export const routes = [
   {
     path: '*',
     element: NotFound,
+    chunkId: 'src/pages/not-found/NotFound.jsx',
     status: 404,
   },
 ];

--- a/src/server.js
+++ b/src/server.js
@@ -9,6 +9,7 @@ import fs from 'node:fs/promises';
 import express from 'express';
 import { Transform } from 'node:stream';
 import { getRoutes } from './routes/routes.js';
+import { routes } from './routes/config.js';
 import { base, getServerConfig } from './config/server-config.js';
 import i18nextMiddleware from 'i18next-http-middleware';
 import i18n from './i18n.server.js';
@@ -17,6 +18,34 @@ import { setBaseUrl } from './service/postHandlers.js';
 // Constants
 const isProduction = process.env.NODE_ENV === 'production';
 const ABORT_DELAY = 10000;
+
+/**
+ * Load the Vite SSR manifest once at startup in production.
+ *
+ * The manifest maps source module paths to their hashed built asset filenames:
+ *   { "src/pages/welcome/Welcome.jsx": ["assets/Welcome-[hash].js", ...] }
+ *
+ * It serves two purposes:
+ *   1. Injected into window.__SSR_MANIFEST__ for the client-side prefetch
+ *      utility (prefetchRoutes.js) to resolve asset URLs for non-active routes.
+ *   2. Used server-side to inject <link rel="modulepreload"> and
+ *      <link rel="preload" as="style"> for the current page's chunks so the
+ *      browser can fetch them in parallel with the HTML stream.
+ */
+let ssrManifest = null;
+if (isProduction) {
+  try {
+    const manifestRaw = await fs.readFile(
+      './dist/client/.vite/ssr-manifest.json',
+      'utf-8',
+    );
+    ssrManifest = JSON.parse(manifestRaw);
+  } catch {
+    console.warn(
+      'SSR manifest not found — preload hints and prefetch will be disabled.',
+    );
+  }
+}
 
 // Get available port
 const { port, baseUrl } = await getServerConfig();
@@ -95,10 +124,7 @@ app.use('*all', async (req, res) => {
       template = await vite.transformIndexHtml(transformUrl, template);
       render = (await vite.ssrLoadModule('/src/entry-server.jsx')).render;
     } else {
-      const templateHtml = isProduction
-        ? await fs.readFile('./dist/client/index.html', 'utf-8')
-        : '';
-      template = templateHtml;
+      template = await fs.readFile('./dist/client/index.html', 'utf-8');
       render = (await import('../dist/server/entry-server.js')).render;
     }
 
@@ -138,6 +164,27 @@ app.use('*all', async (req, res) => {
           htmlStartProcessed = themeAttr
             ? htmlStartProcessed.replace('<html', `<html${themeAttr}`)
             : htmlStartProcessed;
+
+          // Inject the SSR manifest for client-side route prefetching and
+          // server-side preload hints. Both use the same manifest object.
+          if (ssrManifest) {
+            // Serialize the manifest into window.__SSR_MANIFEST__ so the
+            // client-side prefetchRoutes() utility can resolve asset URLs for
+            // non-active routes without bundling the manifest into the JS.
+            const manifestScript = `<script>window.__SSR_MANIFEST__ = ${JSON.stringify(ssrManifest).replace(/</g, '\\u003c')}</script>`;
+
+            // Generate <link rel="modulepreload"> and <link rel="preload" as="style">
+            // for the current page's chunks. The server knows which route is being
+            // rendered before the browser receives any HTML — emitting these hints
+            // lets the browser fetch the page chunk in parallel with the stream
+            // rather than waiting for the parser to discover the <script> tag.
+            const preloadLinks = buildPreloadLinks(url, ssrManifest);
+
+            htmlStartProcessed = htmlStartProcessed.replace(
+              '</head>',
+              `${preloadLinks}${manifestScript}</head>`,
+            );
+          }
 
           res.write(htmlStartProcessed);
 
@@ -179,6 +226,48 @@ app.use('*all', async (req, res) => {
       .end('Internal Server Error');
   }
 });
+
+/**
+ * Builds <link rel="modulepreload"> and <link rel="preload" as="style"> tags
+ * for the current page's assets using the Vite SSR manifest.
+ *
+ * The server knows which route is being rendered before the browser receives
+ * a single byte of HTML. Emitting these hints causes the browser to fetch the
+ * page-specific JS and CSS chunks in parallel with the HTML stream rather than
+ * waiting for the parser to discover the <script> tag later.
+ *
+ * @param {string} url - The current request URL path
+ * @param {Object} manifest - The parsed Vite SSR manifest
+ * @returns {string} HTML string of <link> tags to inject into <head>
+ */
+function buildPreloadLinks(url, manifest) {
+  // Find the route whose path matches the current URL
+  const matchedRoute = routes.find((route) => {
+    if (!route.path || !route.element) return false;
+    if (route.path === url || route.path === `/${url}`) return true;
+    // Match dynamic segments: /dashboard/:id matches /dashboard/123
+    const staticPart = route.path.split('/:')[0];
+    return staticPart !== route.path && url.startsWith(staticPart);
+  });
+
+  if (!matchedRoute?.chunkId) return '';
+
+  // chunkId matches the manifest key exactly (e.g. 'src/pages/welcome/Welcome.jsx')
+  const assets = manifest[matchedRoute.chunkId] ?? [];
+
+  return assets
+    .map((asset) => {
+      const href = asset.startsWith('/') ? asset : `/${asset}`;
+      if (asset.endsWith('.js')) {
+        return `<link rel="modulepreload" href="${href}">`;
+      }
+      if (asset.endsWith('.css')) {
+        return `<link rel="preload" as="style" href="${href}">`;
+      }
+      return '';
+    })
+    .join('\n  ');
+}
 
 // Start http server
 const server = app.listen(port, () => {

--- a/src/utils/prefetchRoutes.js
+++ b/src/utils/prefetchRoutes.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Prefetches the JS and CSS chunks for every route that is not currently
+ * active, after the browser has finished its initial work.
+ *
+ * This mirrors the "prefetch on idle" strategy used by Next.js: the current
+ * page loads synchronously, while every other route's assets are fetched
+ * speculatively at low priority in the background. When the user navigates,
+ * the chunks are already in the browser cache and the transition is instant.
+ *
+ * Asset URLs are resolved from the Vite SSR manifest, which is injected into
+ * window.__SSR_MANIFEST__ by the server using the same pattern as i18n state.
+ * The manifest maps source module paths to hashed built asset filenames:
+ *   { "src/pages/welcome/Welcome.jsx": ["assets/Welcome-[hash].js", ...] }
+ *
+ * Only runs in production — in development Vite serves modules dynamically
+ * and the manifest is not available.
+ *
+ * @param {Array} routes - The full routes config array from src/routes/config.js
+ * @param {string} currentPathname - The pathname of the currently active route
+ */
+export function prefetchRoutes(routes, currentPathname) {
+  if (!import.meta.env.PROD) return;
+
+  const manifest = window.__SSR_MANIFEST__;
+  if (!manifest) return;
+
+  const schedule =
+    typeof requestIdleCallback !== 'undefined'
+      ? (fn) => requestIdleCallback(fn, { timeout: 2000 })
+      : (fn) => setTimeout(fn, 200);
+
+  schedule(() => {
+    // Only prefetch routes that have a chunkId (real page components).
+    // Virtual/external links have no element or chunkId so are skipped.
+    const prefetchable = routes.filter(
+      (route) =>
+        route.chunkId &&
+        route.path &&
+        !isActiveRoute(route.path, currentPathname),
+    );
+
+    prefetchable.forEach((route) => {
+      // chunkId matches the manifest key exactly, e.g. 'src/pages/welcome/Welcome.jsx'
+      const assets = manifest[route.chunkId] ?? [];
+      assets.forEach(insertPrefetchLink);
+    });
+  });
+}
+
+/**
+ * Returns true if the route path matches the current pathname.
+ * Uses a simple prefix check for dynamic segments (e.g. /dashboard/:id).
+ *
+ * @param {string} routePath
+ * @param {string} currentPathname
+ * @returns {boolean}
+ */
+function isActiveRoute(routePath, currentPathname) {
+  if (routePath === currentPathname) return true;
+  // Treat /path/:param routes as active when /path/* is current
+  const staticPart = routePath.split('/:')[0];
+  return staticPart !== routePath && currentPathname.startsWith(staticPart);
+}
+
+/**
+ * Inserts a <link rel="prefetch"> element for the given asset URL if one
+ * does not already exist in the document head.
+ *
+ * @param {string} asset - Relative asset path from the manifest
+ */
+function insertPrefetchLink(asset) {
+  const href = asset.startsWith('/') ? asset : `/${asset}`;
+  if (document.querySelector(`link[rel="prefetch"][href="${href}"]`)) return;
+
+  const link = document.createElement('link');
+  link.rel = 'prefetch';
+  link.href = href;
+
+  if (href.endsWith('.css')) {
+    link.as = 'style';
+  } else if (href.endsWith('.js')) {
+    link.as = 'script';
+  }
+
+  document.head.appendChild(link);
+}

--- a/stylelint-plugins/no-carbon-full-entrypoint.cjs
+++ b/stylelint-plugins/no-carbon-full-entrypoint.cjs
@@ -1,0 +1,66 @@
+/**
+ * Copyright IBM Corp. 2025, 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Custom Stylelint plugin: no-carbon-full-entrypoint
+ *
+ * Prevents importing the full Carbon or IBM Products entrypoints outside of
+ * src/index.scss. Importing them in a component SCSS file silently duplicates
+ * the entire Carbon stylesheet (~1.8 MB unminified) into that chunk.
+ *
+ * Allowed everywhere:
+ *   @use '@carbon/react/scss/spacing'    — token/mixin sub-path, emits no CSS
+ *   @use '@carbon/react/scss/theme'      — mixin sub-path, emits no CSS
+ *   @use '@carbon/react/scss/breakpoint' — mixin sub-path, emits no CSS
+ *
+ * Disallowed outside src/index.scss:
+ *   @use '@carbon/react'               — emits all Carbon component CSS
+ *   @use '@carbon/ibm-products'        — emits all IBM Products CSS
+ *   @use '@carbon/ibm-products/css/...'— compiled monolith CSS import
+ */
+
+const RULE_NAME = 'plugin/no-carbon-full-entrypoint';
+
+// Matches the root entrypoints that emit full CSS — not sub-path SCSS imports
+const DISALLOWED_PATTERNS = [
+  /^['"]@carbon\/react['"]/,
+  /^['"]@carbon\/ibm-products(?!\/scss\/)['"]/,
+];
+
+/** @type {import('stylelint').Rule} */
+const rule = (primaryOption) => {
+  return (root, result) => {
+    if (primaryOption === false) return;
+
+    const filePath = root.source?.input?.file ?? '';
+
+    // Allow unrestricted use in the global entry point
+    if (filePath.endsWith('index.scss')) return;
+
+    root.walkAtRules('use', (atRule) => {
+      const params = atRule.params?.trim() ?? '';
+      const isDisallowed = DISALLOWED_PATTERNS.some((pattern) =>
+        pattern.test(params),
+      );
+
+      if (isDisallowed) {
+        result.warn(
+          `Do not import the full Carbon entrypoint '${params}' outside src/index.scss. ` +
+            `This duplicates all Carbon component CSS into this file's output chunk. ` +
+            `Use sub-path imports instead (e.g. '@carbon/react/scss/spacing') — ` +
+            `they expose only SCSS variables and mixins with no CSS output.`,
+          { node: atRule, ruleName: RULE_NAME, word: params },
+        );
+      }
+    });
+  };
+};
+
+rule.ruleName = RULE_NAME;
+rule.meta = { url: '' };
+
+module.exports = { ruleName: RULE_NAME, rule };

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,72 @@ import i18nextLoader from 'vite-plugin-i18next-loader';
 
 // https://vite.dev/config/
 export default defineConfig({
+  build: {
+    /**
+     * Expected chunk size breakdown:
+     *   vendor-carbon  — large, expected, see threshold comment below
+     *   index          — app shell (Nav, routing, i18n bootstrap)
+     *   page chunks    — small, one per route (Welcome, Dashboard, etc.)
+     *
+     * Threshold is set to 3× the measured vendor-carbon baseline to give ample
+     * headroom for a full-featured IBM product UI using most of Carbon's
+     * component library. Revisit if vendor-carbon consistently approaches the
+     * limit after adding many new Carbon dependencies.
+     *
+     * Baseline measured on this starter: vendor-carbon = 298 kB (86 kB gzip).
+     * 3× = 894 kB → rounded up to 1,000 kB.
+     */
+    chunkSizeWarningLimit: 1000,
+    rollupOptions: {
+      output: {
+        /**
+         * Isolate all Carbon, IBM, and Carbon Labs packages into a single
+         * vendor chunk. This chunk is large but cached permanently after the
+         * first visit — application-code deploys no longer bust the browser
+         * cache for the entire library.
+         *
+         * CSS from Carbon stays in index.css (via src/index.scss). This only
+         * affects JS chunking.
+         */
+        manualChunks(id) {
+          if (
+            id.includes('node_modules/@carbon/') ||
+            id.includes('node_modules/@ibm/') ||
+            id.includes('node_modules/@carbon-labs/')
+          ) {
+            return 'vendor-carbon';
+          }
+        },
+      },
+      /**
+       * Suppress the expected LARGE_BUNDLE warning for vendor-carbon and
+       * surface an actionable error for any other unexpectedly large chunk.
+       * The most likely cause is a page component importing '@carbon/react'
+       * or '@carbon/ibm-products' directly — see src/index.scss for the
+       * correct import pattern and .stylelintrc.json for the lint rule that
+       * catches this before build time.
+       */
+      onwarn(warning, warn) {
+        if (
+          warning.code === 'LARGE_BUNDLE' &&
+          warning.message?.includes('vendor-carbon')
+        ) {
+          return; // expected — vendor-carbon is intentionally large
+        }
+        if (warning.code === 'LARGE_BUNDLE') {
+          warn(
+            `${warning.message}\n` +
+              `  Unexpected large chunk detected. If a page chunk is oversized, ` +
+              `check that it does not import '@carbon/react' or '@carbon/ibm-products' ` +
+              `directly. Those imports belong only in src/index.scss. ` +
+              `See the Stylelint rule in .stylelintrc.json for automated enforcement.`,
+          );
+          return;
+        }
+        warn(warning);
+      },
+    },
+  },
   plugins: [
     react(),
     /**

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,7 +27,11 @@ export default defineConfig({
      * 3× = 894 kB → rounded up to 1,000 kB.
      */
     chunkSizeWarningLimit: 1000,
-    rollupOptions: {
+    /**
+     * build.rolldownOptions replaces the deprecated build.rollupOptions in
+     * Vite 8 (Rolldown-based). The API is a superset of Rollup's options.
+     */
+    rolldownOptions: {
       output: {
         /**
          * Isolate all Carbon, IBM, and Carbon Labs packages into a single
@@ -35,17 +39,19 @@ export default defineConfig({
          * first visit — application-code deploys no longer bust the browser
          * cache for the entire library.
          *
+         * codeSplitting.groups replaces the deprecated manualChunks function
+         * in Vite 8 / Rolldown. The test regex matches the same packages.
+         *
          * CSS from Carbon stays in index.css (via src/index.scss). This only
          * affects JS chunking.
          */
-        manualChunks(id) {
-          if (
-            id.includes('node_modules/@carbon/') ||
-            id.includes('node_modules/@ibm/') ||
-            id.includes('node_modules/@carbon-labs/')
-          ) {
-            return 'vendor-carbon';
-          }
+        codeSplitting: {
+          groups: [
+            {
+              test: /node_modules\/@carbon\/|node_modules\/@ibm\/|node_modules\/@carbon-labs\//,
+              name: 'vendor-carbon',
+            },
+          ],
         },
       },
       /**


### PR DESCRIPTION
- Colocate page SCSS with page components (Welcome, Dashboard) so Vite emits separate CSS chunks per route instead of a single monolith
- Add manualChunks in vite.config.js to isolate all @carbon/* and @ibm/* JS into a vendor-carbon chunk — cached permanently, independent of app-code deploys
- Add chunkSizeWarningLimit (1000 kB, 3x baseline) and onwarn handler that suppresses the expected vendor-carbon warning and surfaces an actionable error for any other oversized chunk
- Add custom Stylelint plugin (no-carbon-full-entrypoint) that errors when a full Carbon entrypoint is imported outside src/index.scss, preventing silent CSS duplication regressions
- Document the global-only contract in src/index.scss with inline comments explaining which imports belong globally vs per-component
- Inject window.__SSR_MANIFEST__ server-side for client-side route prefetching; add prefetchRoutes() utility that fires on requestIdleCallback after first paint and inserts rel=prefetch links for all non-active routes
- Inject modulepreload and preload hints server-side for the current page's chunks so the browser fetches them in parallel with the HTML
- Add chunkId to each route config entry as the stable manifest key
- Add docs/css-and-js-splitting.md as the developer-facing reference