### PR TITLE
fix: add rate limiting to SSR HTML route handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "classnames": "^2.5.1",
         "compression": "^1.7.5",
         "express": "^5.0.1",
+        "express-rate-limit": "^8.6.1",
         "i18next": "^26.0.0",
         "i18next-browser-languagedetector": "^8.2.0",
         "i18next-fs-backend": "^2.6.0",
@@ -9036,6 +9037,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/express/node_modules/content-type": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "classnames": "^2.5.1",
     "compression": "^1.7.5",
     "express": "^5.0.1",
+    "express-rate-limit": "^8.6.1",
     "i18next": "^26.0.0",
     "i18next-browser-languagedetector": "^8.2.0",
     "i18next-fs-backend": "^2.6.0",

--- a/src/server.js
+++ b/src/server.js
@@ -7,6 +7,7 @@
 
 import fs from 'node:fs/promises';
 import express from 'express';
+import { rateLimit } from 'express-rate-limit';
 import { Transform } from 'node:stream';
 import { getRoutes } from './routes/routes.js';
 import { base, getServerConfig } from './config/server-config.js';
@@ -74,8 +75,16 @@ app.use(
 // Register API routes
 getRoutes(app);
 
+// Rate limit the SSR HTML handler — it performs file system reads on every request
+const htmlLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  limit: 500,
+  standardHeaders: 'draft-8',
+  legacyHeaders: false,
+});
+
 // Serve HTML
-app.use('*all', async (req, res) => {
+app.use('*all', htmlLimiter, async (req, res) => {
   try {
     const url = req.originalUrl.replace(base, '');
 


### PR DESCRIPTION
## Summary

Addresses CodeQL security alert [js/missing-rate-limiting (#12)](https://github.com/carbon-design-system/carbon-react-router-starter/security/code-scanning/12).

The catch-all SSR handler in `src/server.js` performs file system reads (`fs.readFile`) on every request without any rate limiting, making it vulnerable to denial-of-service attacks (CWE-307, CWE-400, CWE-770).

## Changes

- Adds `express-rate-limit` dependency
- Applies a rate limiter (500 requests / 15-minute window) to the `*all` HTML route handler in `src/server.js`

## References

- [OWASP Denial of Service Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Denial_of_Service_Cheat_Sheet.html)
- [express-rate-limit](https://www.npmjs.com/package/express-rate-limit)