### PR TITLE
fix: replace deprecated ::set-output in CI workflows

### DIFF
--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Read .nvmrc
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
         id: nvm
       - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
         uses: actions/setup-node@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Read .nvmrc
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
         id: nvm
 
       - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}


### PR DESCRIPTION
## Summary

Replaces the deprecated `::set-output` workflow command in `buildTest.yml`
and `release.yml` with the modern `$GITHUB_OUTPUT` environment file approach.

GitHub deprecated `::set-output` in September 2022. Current runners emit a
warning and it still works, but it will be disabled on future runners. This
replaces it before it breaks.

The `ssr-test.yml` workflow already used the correct syntax — this brings
the remaining two workflows into line with it.

## Changes

- `.github/workflows/buildTest.yml` — line 14
- `.github/workflows/release.yml` — line 32

## Testing

- `actionlint` passes with no errors on both changed files
- CI on fork: https://github.com/sahul-e/carbon-react-router-starter/actions

Fixes #694